### PR TITLE
setup packages used by fastai course

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Setup a paperspace instance for fastai. Steps:
 
 - Open a terminal on your machine
+- `cd /storage`
 - `git clone https://github.com/fastai/paperspace-setup.git`
 - `cd paperspace-setup`
 - `./setup.sh`

--- a/setup.sh
+++ b/setup.sh
@@ -1,13 +1,20 @@
 #!/usr/bin/env bash
 
-mkdir /storage/cfg
-ln -sf `pwd`/pre-run.sh /storage/pre-run.sh
-ln -sf `pwd`/.bash.local /storage/
+pushd $(dirname "$0")     # change to folder containing script
 
-./pre-run.sh
-source ./.bash.local
+mkdir -p /storage/cfg
+ln -sf `pwd`/pre-run.sh /storage/pre-run.sh
+ln -sf `pwd`/.bash.local /storage/.bash.local
+
+/storage/pre-run.sh
+source /storage/.bash.local
 shopt -s expand_aliases
+
 pipi -U fastai kaggle "timm>=0.6.2dev"
 mambai --yes -c conda-forge  universal-ctags  unzip  pv 
+mambai --yes -c fastai nvidia-ml-py3 
+
+popd   # return to original folder 
 
 echo install complete. please start a new instance
+

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 
 mkdir /storage/cfg
-cp pre-run.sh /storage/
-cp .bash.local /storage/
+ln -sf `pwd`/pre-run.sh /storage/pre-run.sh
+ln -sf `pwd`/.bash.local /storage/
+
+./pre-run.sh
+source ./.bash.local
+shopt -s expand_aliases
+pipi -U fastai kaggle "timm>=0.6.2dev"
+mambai --yes -c conda-forge  universal-ctags  unzip  pv 
+
 echo install complete. please start a new instance


### PR DESCRIPTION
Wondering whether any of these seem worthwhile:
1. Cloning into global **/storage** rather than **/notebook**

2. Linking instead of copying helps use git to manage configuration

3. Could set up a few packages used by fastai course - or maybe better to leave for learners to experience during the course 

p.s. I find that I can't use ```!pipi -U somepkg``` from within a notebook.  I wonder if a script wrapper for pip and mamba in **/root/.local/bin** would better than alias.
or maybe something like this... (note, I haven't tried it)
https://www.quora.com/How-can-I-make-IPython-import-the-aliases-defined-in-my-bash-profile-upon-startup